### PR TITLE
🔒 Fix missing noopener noreferrer on LinkElement

### DIFF
--- a/src/lib/components/LinkElement.svelte
+++ b/src/lib/components/LinkElement.svelte
@@ -8,6 +8,6 @@
 	}: { href: string; blank?: boolean; children: Snippet } = $props();
 </script>
 
-<a {href} target={blank ? '_blank' : ''} class="flex items-center">
+<a {href} target={blank ? '_blank' : undefined} rel={blank ? 'noopener noreferrer' : undefined} class="flex items-center">
 	{@render children()}
 </a>


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `LinkElement.svelte` where `target="_blank"` was missing `rel="noopener noreferrer"`.
⚠️ **Risk:** Reverse tabnabbing vulnerability. Without `rel="noopener noreferrer"`, the newly opened page gains access to the original window object via `window.opener`, potentially allowing an attacker to maliciously redirect or interact with the original site.
🛡️ **Solution:** Added `rel={blank ? "noopener noreferrer" : undefined}` and changed the default for target to `undefined` (omitting it) instead of an empty string, enforcing secure behavior when linking to external domains.

---
*PR created automatically by Jules for task [10672994434125798817](https://jules.google.com/task/10672994434125798817) started by @Sparkier*