### PR TITLE
🧹 Refactor: Extract organicNoise function to utility

### DIFF
--- a/src/lib/utils/math.ts
+++ b/src/lib/utils/math.ts
@@ -1,0 +1,8 @@
+export function organicNoise(t: number, seed: number): number {
+	return (
+		Math.sin(t * 0.7 + seed) * 0.4 +
+		Math.sin(t * 1.3 + seed * 1.618) * 0.3 +
+		Math.sin(t * 2.1 + seed * 2.414) * 0.2 +
+		Math.sin(t * 3.7 + seed * 0.618) * 0.1
+	);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,18 +3,10 @@
 	import { getBlogEntries } from '$lib/helpers/blogProvider';
 	import { getResearchProjects, slugify } from '$lib/helpers/projectsProvider';
 	import type { BlogEntry, ResearchProject } from '$lib/types';
+	import { organicNoise } from '$lib/utils/math';
 
 	const featuredPosts: BlogEntry[] = getBlogEntries().slice(0, 4);
 	const featuredPapers: ResearchProject[] = getResearchProjects().slice(0, 5);
-
-	function organicNoise(t: number, seed: number): number {
-		return (
-			Math.sin(t * 0.7 + seed) * 0.4 +
-			Math.sin(t * 1.3 + seed * 1.618) * 0.3 +
-			Math.sin(t * 2.1 + seed * 2.414) * 0.2 +
-			Math.sin(t * 3.7 + seed * 0.618) * 0.1
-		);
-	}
 
 	const systems = [
 		{


### PR DESCRIPTION
🎯 **What:** Extracted the pure function `organicNoise` from `src/routes/+page.svelte` into a new utility module `src/lib/utils/math.ts`.
💡 **Why:** It removes a pure calculation function from a component file, reducing code pollution and improving the file's readability and maintainability.
✅ **Verification:** Ran `npm run build` to verify no errors exist. Checked the logic to ensure the math utility behaves the same as it originally did.
✨ **Result:** Improved separation of concerns, cleaner component file, and reusable math logic.

---
*PR created automatically by Jules for task [13121459311160139959](https://jules.google.com/task/13121459311160139959) started by @Sparkier*