### PR TITLE
🧹 Remove Unused Svelte Component Import in types.ts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,3 @@
-import type { Component } from 'svelte';
-
 /**
  * Providing a structure for reviewing and academic service
  */


### PR DESCRIPTION
🎯 **What:** Removed an unused type import (`Component`) from `src/lib/types.ts`.
💡 **Why:** The file previously imported `Component` from Svelte but didn't use it anywhere in the file. Removing dead code reduces noise, prevents confusion, and improves overall codebase cleanliness.
✅ **Verification:** Verified with `bun run vitest run` and `bun run check`. No tests are broken since it was an unused import.
✨ **Result:** Cleaned up `src/lib/types.ts` making it slightly easier to read.

---
*PR created automatically by Jules for task [15003991199444788593](https://jules.google.com/task/15003991199444788593) started by @Sparkier*