### PR TITLE
🔒 Fix reverse tabnabbing vulnerability in LinkElement

### DIFF
--- a/src/lib/components/LinkElement.svelte
+++ b/src/lib/components/LinkElement.svelte
@@ -8,6 +8,6 @@
 	}: { href: string; blank?: boolean; children: Snippet } = $props();
 </script>
 
-<a {href} target={blank ? '_blank' : undefined} rel={blank ? 'noopener noreferrer' : undefined} class="flex items-center">
+<a {href} target={blank ? '_blank' : undefined} rel="noopener noreferrer" class="flex items-center">
 	{@render children()}
 </a>


### PR DESCRIPTION
🎯 **What:** Fixed a potential reverse tabnabbing vulnerability in `LinkElement.svelte`.
⚠️ **Risk:** By only conditionally applying `rel="noopener noreferrer"`, there was a risk that if `blank` is falsely evaluated or if a user opens a link in a new tab via other means (like middle-clicking an external link), the newly opened page would have access to the `window.opener` object. This could allow a malicious site to navigate the original tab to a phishing page.
🛡️ **Solution:** Changed the `rel` attribute to unconditionally apply `"noopener noreferrer"` for all links rendered by this component. This guarantees that `window.opener` is never accessible, regardless of whether `target="_blank"` was applied conditionally or by user action.

---
*PR created automatically by Jules for task [6563436105308795471](https://jules.google.com/task/6563436105308795471) started by @Sparkier*